### PR TITLE
add Donate link to the navbar

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -22,6 +22,9 @@
                 <a href="{{ 'volunteer.html' | relative_url }}">
                     <button class="navbutton">Volunteer</button>
                 </a>
+                <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=8MDXJKC6NVZ3G&source=url">
+                    <button class="navbutton">Donate</button>
+                </a>
                 <a href="{{ 'signup.html' | relative_url }}">
                     <button class="navbutton action-button tinybutton">Sign Up</button>
                 </a>


### PR DESCRIPTION
![Screenshot_20200610_194808](https://user-images.githubusercontent.com/17362949/84339650-becd9200-ab53-11ea-9f53-0926c3716981.png)

link should be working, **have not tested layouts on mobile** to see if the nav items are overlap other stuff on screens that are just barely too big for the hamburger menu to appear 