### PR TITLE
remove .html from internal links

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,5 +1,5 @@
 <nav id="topnav">
-    <a href="{{ 'index.html' | relative_url }}">
+    <a href="{{ 'index.html' | relative_url | remove: '.html' }}">
         <img src="imgs/Logo.svg" id="navlogo">
     </a>
     <input class="checkbox-toggle mobile" type="checkbox"/>
@@ -10,19 +10,19 @@
     <nav id="topnav-right">
         <div>
             <div>
-                <a href="{{ 'index.html' | relative_url }}">
+                <a href="{{ '/' | relative_url | remove: '.html' }}">
                     <button class="navbutton">Home</button>
                 </a>
-                <a href="{{ 'faqs.html' | relative_url }}">
+                <a href="{{ 'faqs.html' | relative_url | remove: '.html' }}">
                     <button class="navbutton">FAQ</button>
                 </a>
-                <a href="{{ 'about.html' | relative_url }}">
+                <a href="{{ 'about.html' | relative_url | remove: '.html' }}">
                     <button class="navbutton">About</button>
                 </a>
-                <a href="{{ 'getinvolved.html' | relative_url }}">
+                <a href="{{ 'getinvolved.html' | relative_url | remove: '.html' }}">
                     <button class="navbutton">Get Involved</button>
                 </a>
-                <a href="{{ 'signup.html' | relative_url }}">
+                <a href="{{ 'signup.html' | relative_url | remove: '.html' }}">
                     <button class="action-button tinybutton">Sign Up</button>
                 </a>
             </div>

--- a/covid.html
+++ b/covid.html
@@ -11,7 +11,7 @@ style: about.css
     processing fee. We’ll keep you posted on developments.
 </p>
 <p>
-    Register soon to reserve your spot! Sign up <a href="{{ 'signup.html' | relative_url }}">here</a> and we’ll notify you of any updates.
+    Register soon to reserve your spot! Sign up <a href="{{ 'signup.html' | relative_url | remove: '.html' }}">here</a> and we’ll notify you of any updates.
 </p>
 <ul>
     <li> <strong>Social Distancing: </strong> If the camp is in-person, we may limit the number of participants to ensure that we are within state and local limits and can maintain 6 feet

--- a/getinvolved.html
+++ b/getinvolved.html
@@ -50,7 +50,7 @@ style: style.css
             
             </details>
         </section>
-        <p>If you’re interested in helping, read more about the <a href="volunteerinfo.html#formfunction">volunteer positions</a> and then fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSdeQS-f01BjjV78_TtXTntbJXLUjKtZBRu-zllyHffF6ytnMQ/viewform">the volunteer application form</a>. If you have any questions, contact us at {{site.contact.email}}!
+        <p>If you’re interested in helping, read more about the <a href="{{ 'volunteerinfo.html#formfunction' | relative_url | remove: '.html' }}">volunteer positions</a> and then fill out <a href="https://docs.google.com/forms/d/e/1FAIpQLSdeQS-f01BjjV78_TtXTntbJXLUjKtZBRu-zllyHffF6ytnMQ/viewform">the volunteer application form</a>. If you have any questions, contact us at {{site.contact.email}}!
         </p>
     </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@ style: index.css
                         Online: FREE (suggested donation: $30)</p>
                 </div>
                 <div>
-                    <a href="{{ 'signup.html' | relative_url }}"><button class="action-button largebutton">Sign Up</button></a>
+                    <a href="{{ 'signup.html' | relative_url | remove: '.html' }}"><button class="action-button largebutton">Sign Up</button></a>
                 </div>
             </div>
             <!-- <div class="details-item">


### PR DESCRIPTION
This pull request takes advantage of the fact that both jekyll and github pages will intelligently serve requests to, for example, https://bitbybitcoding.org/signup using the signup.html file we already have. This makes links a lot cleaner.

you can ALREADY visit pages on our site without the .html (try clicking the link above :P), but the links between pages on our site still use the .html version.

this pull request updates our internal links to be cleaner.
